### PR TITLE
Add check if path found via flutter sdk exists

### DIFF
--- a/src/lib/sdk.ts
+++ b/src/lib/sdk.ts
@@ -64,7 +64,8 @@ class FlutterSDK {
       // => cache/dart-sdk
       await this.initDarkSdkHomeFromFlutter(flutterLookup);
       // if do not have flutter sdk, detect dart sdk
-      if (!this._dartHome) {
+      const isPathExists = await exists(this._dartHome);
+      if (!isPathExists) {
         await this.initDarkSdkHome(dartLookup);
       }
       await this.initDartSdk();


### PR DESCRIPTION
Hei there

When using your extension under nixos there is a problem with the way you implemented the sdk lookup via `which flutter`. 

By checking if this path actually exists and if not try to lookup the sdk via `which dart` I was able to successfully run your plugin :) 

Cheers