### PR TITLE
Update documentation to reflect code settings for `onlyAnalyzeProjectsWithOpenFiles` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Flutter support for (Neo)vim
 - `flutter.trace.server` Trace level of log, default: `off`
 - `flutter.enabled` Enable coc-flutter extension, default: `true`
 - `flutter.lsp.debug` Enable debug for language server, default: `false`
-- `flutter.lsp.initialization.onlyAnalyzeProjectsWithOpenFiles`: default: `false`
+- `flutter.lsp.initialization.onlyAnalyzeProjectsWithOpenFiles`: default: `true`
   > When set to true, analysis will only be performed for projects that have open files rather than the root workspace folder.
 - `flutter.lsp.initialization.suggestFromUnimportedLibraries`: default: `true`
   > When set to false, completion will not include synbols that are not already imported into the current file


### PR DESCRIPTION
According to the source code, the `onlyAnalyzeProjectsWithOpenFiles` setting is `true` by default. But the `README.md` contained information that this option is `false` by default.

This commit fixes the `false` default value to `true` in `README.md`.