### PR TITLE
Add command to launch devtools debugger in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Flutter support for (Neo)vim
 - `flutter.openDevLogSplitCommand` Vim command to open dev log window, like: `botright 10split`, default: ''
 - `flutter.workspaceFolder.ignore` Path start within the list will not treat as workspaceFolder, default: []
   - also flutter sdk will not treat as workspaceFolder, more detail issues [50](https://github.com/iamcco/coc-flutter/issues/50)
+- `flutter.runDevToolsAtStartup` Automatically open devtools debugger web page when a project is run, default: 'false'
 
 
 **Enable format on save**:
@@ -126,6 +127,7 @@ Open flutter only commands list: `CocList --input=flutter commands`
 - `flutter.dev.screenshot` To save a screenshot to flutter.png
 - `flutter.dev.openDevLog` Open flutter dev server log
 - `flutter.dev.openProfiler` Open observatory debugger and profiler web page
+- `flutter.dev.openDevToolsProfiler` Open devtools debugger web page
 - `flutter.dev.debugDumpAPP` You can dump the widget hierarchy of the app (debugDumpApp)
 - `flutter.dev.elevationChecker` To toggle the elevation checker
 - `flutter.dev.debugDumpLayerTree` For layers (debugDumpLayerTree)

--- a/package.json
+++ b/package.json
@@ -122,6 +122,11 @@
           "default": [],
           "item": "string",
           "description": "Path start within the list will not treat as workspaceFolder"
+        },
+        "flutter.runDevToolsAtStartup": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically run the DevTools debugger in a web browser when running a project"
         }
       }
     },

--- a/src/server/devtools/index.ts
+++ b/src/server/devtools/index.ts
@@ -1,0 +1,181 @@
+import os from 'os';
+import { workspace } from 'coc.nvim';
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
+
+import { getFlutterWorkspaceFolder } from '../../util/fs';
+import { logger } from '../../util/logger';
+import { notification } from '../../lib/notification';
+import { Dispose } from '../../util/dispose';
+
+const log = logger.getlog('devtools-server');
+
+type callback = (...params: any[]) => void;
+
+class DevToolsServer extends Dispose {
+  private launchDevToolsTask: ChildProcessWithoutNullStreams | undefined;
+  private activateDevToolsTask: ChildProcessWithoutNullStreams | undefined;
+  private port: number | undefined;
+  private PID: number | undefined;
+  private host: string | undefined;
+  private onHandler: callback[] = [];
+
+  constructor() {
+    super();
+    this.push({
+      dispose: () => {
+        this.port = undefined;
+        this.PID = undefined;
+        this.host = undefined;
+        if (this.launchDevToolsTask) {
+          try {
+            this.launchDevToolsTask.kill();
+            this.launchDevToolsTask = undefined;
+          } catch (error) {
+            log(`dispose server error: ${error.message}`);
+          }
+        }
+      },
+    });
+  }
+
+  get state(): boolean {
+    return !!(this.launchDevToolsTask && this.port && this.host && this.PID);
+  }
+
+  get devToolsUri(): string | undefined {
+    return this.state ? `${this.host}:${this.port}` : undefined;
+  }
+
+  private _onError = (err: Error) => {
+    this.launchDevToolsTask = undefined;
+    log(`devtools server error: ${err.message}`);
+  };
+
+  private _onExit = (code: number) => {
+    this.launchDevToolsTask = undefined;
+    log(`devtools server exit with: ${code}`);
+  };
+
+  async start(): Promise<boolean> {
+    if (this.state) {
+      notification.show('Flutter devtools is running!');
+      return false;
+    }
+
+    const workspaceFolder: string | undefined = await getFlutterWorkspaceFolder();
+    if (!workspaceFolder) {
+      notification.show('Flutter project workspaceFolder not found!');
+      return false;
+    }
+
+    notification.show('Launching flutter devtools...');
+
+    // run devtools server, look for an open port if default is unavailable, return output in JSON format
+    this.launchDevToolsTask = spawn('flutter', ['pub', 'global', 'run', 'devtools', '--machine', '--try-ports', '10'], {
+      cwd: workspaceFolder,
+      detached: false,
+      shell: os.platform() === 'win32' ? true : undefined,
+    });
+    this.launchDevToolsTask.on('exit', this._onExit);
+    this.launchDevToolsTask.on('error', this._onError);
+
+    if (this.onHandler.length) {
+      this.onHandler.forEach(cb => cb());
+      this.onHandler = [];
+    }
+    return true;
+  }
+
+  onStdout(handler: callback): void {
+    const callback = () => {
+      this.launchDevToolsTask!['stdout'].on('data', (chunk: Buffer) => {
+        const text = chunk.toString();
+        // expecting JSON output because of --machine flag
+        try {
+          const json = JSON.parse(text);
+          this.port = json['params']['port'];
+          this.PID = json['params']['pid'];
+          this.host = json['params']['host'];
+          log(`Devtools running at ${this.host}:${this.port} with PID: ${this.PID}`);
+        } catch (error) {
+          log(`error while parsing ${text}:`);
+          log(error);
+        }
+        handler();
+      });
+    };
+    if (this.launchDevToolsTask && this.launchDevToolsTask['stdout']) {
+      callback();
+    } else {
+      this.onHandler.push(callback);
+    }
+  }
+
+  onStderr(handler: callback): void {
+    const callback = () => {
+      this.launchDevToolsTask!['stderr'].on('data', (chunk: Buffer) => {
+        const text = chunk.toString();
+
+        // If devtools hasn't been activated, the process will write a message to stderr
+        // Check for this message, prompt user to let us activate devtools, and continue if they accept
+        const m = text.match(/No active package devtools/g);
+        if (m) {
+          const devToolsActivationPrompt = workspace.showPrompt(
+            'Flutter pub global devtools has not been activated. Activate now?',
+          );
+          this.handleDevToolsActivationPrompt(devToolsActivationPrompt, handler);
+        }
+        // If devtools fails for some other unknown reason, log the output
+        else {
+          log(text);
+        }
+      });
+    };
+    if (this.launchDevToolsTask && this.launchDevToolsTask['stderr']) {
+      callback();
+    } else {
+      this.onHandler.push(callback);
+    }
+  }
+
+  async handleDevToolsActivationPrompt(activationPrompt: Promise<boolean>, handler: callback) {
+    const value = await activationPrompt;
+    if (value) {
+      const workspaceFolder: string | undefined = await getFlutterWorkspaceFolder();
+      if (!workspaceFolder) {
+        notification.show('Flutter project workspaceFolder not found!');
+        return false;
+      }
+      this.activateDevToolsTask = spawn('flutter', ['pub', 'global', 'activate', 'devtools'], {
+        cwd: workspaceFolder,
+        detached: false,
+        shell: os.platform() === 'win32' ? true : undefined,
+      });
+      this.activateDevToolsTask.on('exit', () => {
+        handler();
+        this.activateDevToolsTask = undefined;
+      });
+      this.activateDevToolsTask.on('error', (err: Error) => {
+        notification.show(`Error activating devtools: ${err.message}`);
+        log(err.message);
+        this.activateDevToolsTask = undefined;
+      });
+      this.push({
+        dispose: () => {
+          if (this.activateDevToolsTask) {
+            try {
+              this.activateDevToolsTask.kill();
+              this.activateDevToolsTask = undefined;
+            } catch (err) {
+              log(`Error disposing activateDevToolsTask: ${err.message}`);
+            }
+          }
+        },
+      });
+    } else {
+      notification.show('You must run "Flutter pub global activate devtools" to launch a devtools browser debugger.');
+    }
+  }
+}
+
+export const devToolsServer = new DevToolsServer();


### PR DESCRIPTION
I find the ability to launch devtools in VS code super useful but prefer working in neovim so I added this functionality as a learning exercise - I haven't done any CoC or typescript development before. I thought I'd offer to share it and maybe close open issue #54 . Some quick notes on the implementation:
- adds a command to launch a devtools debugging browser window 
   - launches devtools by scanning for an available port
  - if launching a debugging window fails because devtools isn't activated, prompt user to activate, activate it for them, and open the debugging window
- adds a config option to launch a debugging window automatically when running a flutter project (disabled by default)

I also added info about the command and config option to the readme. If the code needs work I'm more than happy to make changes given a little direction. I haven't tried contributing on Github before so sorry if I inadvertently did anything dumb. 