### PR TITLE
Added clearDevLog and copyProfilerUrl commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ Open flutter only commands list: `CocList --input=flutter commands`
 - `flutter.dev.hotRestart` Hot restart
 - `flutter.dev.screenshot` To save a screenshot to flutter.png
 - `flutter.dev.openDevLog` Open flutter dev server log
+- `flutter.dev.clearDevLog` Clear the flutter dev server log
 - `flutter.dev.openProfiler` Open observatory debugger and profiler web page
+- `flutter.dev.copyProfilerUrl` Copy the url of observatory debugger and profiler web page to the system clipboard (register +)
 - `flutter.dev.openDevToolsProfiler` Open devtools debugger web page
 - `flutter.dev.debugDumpAPP` You can dump the widget hierarchy of the app (debugDumpApp)
 - `flutter.dev.elevationChecker` To toggle the elevation checker

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -91,6 +91,12 @@ export const cmds: Record<string, DCmd> = {
     cmd: 'q',
     desc: 'Quit server',
   },
+  copyProfilerUrl: {
+    desc: 'Copy the observatory debugger and profiler web page to the system clipboard (register +)',
+    callback: (run: Dev) => {
+      run.copyProfilerUrl();
+    },
+  },
   openProfiler: {
     desc: 'Observatory debugger and profiler web page',
     callback: (run: Dev) => {
@@ -108,6 +114,14 @@ export const cmds: Record<string, DCmd> = {
     callback: () => {
       if (devServer.state) {
         devServer.openDevLog();
+      }
+    },
+  },
+  clearDevLog: {
+    desc: 'Clear the flutter dev server log',
+    callback: () => {
+      if (devServer.state) {
+        devServer.clearDevLog();
       }
     },
   },
@@ -232,6 +246,17 @@ export class Dev extends Dispose {
         notification.show('Flutter server is not running!');
       }
     };
+  }
+
+  async copyProfilerUrl() {
+    if (!this.profilerUrl) {
+      return;
+    }
+    if (devServer.state) {
+      workspace.nvim.command(`let @+='${this.profilerUrl}'`);
+      return;
+    }
+    notification.show('Flutter server is not running!');
   }
 
   openProfiler() {

--- a/src/server/dev/index.ts
+++ b/src/server/dev/index.ts
@@ -144,6 +144,12 @@ class DevServer extends Dispose {
     }
   }
 
+  clearDevLog() {
+    if (this.outputChannel) {
+      this.outputChannel.clear();
+    }
+  }
+
   async openDevLog() {
     const config = workspace.getConfiguration('flutter');
     const cmd = config.get<string>('openDevLogSplitCommand', '');


### PR DESCRIPTION
I added the clearDevLog command since vim tends to slow down when this gets very long.
Also added command to copy the profiler url such that it can be used in devtools (I run the devtools on macos natively instead of in browser)