### PR TITLE
Remove bufenter autocommand to set wrap false for the devlog

### DIFF
--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -15,21 +15,6 @@ class Logger extends Dispose {
       this._outchannel = workspace.createOutputChannel('flutter');
       this.push(this._outchannel);
     }
-    const subscription = workspace.registerAutocmd({
-      event: ['BufEnter'],
-      request: true,
-      callback: async () => {
-        const doc = await workspace.document;
-        const uri = Uri.parse(doc.uri);
-        if (uri && uri.fsPath && uri.fsPath.endsWith(devLogName)) {
-          const { nvim } = workspace;
-          const win = await nvim.window;
-          await win.setOption('wrap', false);
-          subscription.dispose();
-        }
-      },
-    });
-    this.push(subscription);
   }
 
   set outchannel(channel: OutputChannel | undefined) {


### PR DESCRIPTION
The user probably already has his own setting for if he wants it to wrap or not.
Also this fixes #79 and thus improves performance a bit when jumping around files

Fixes #79