### PR TITLE
Corrected log level messages to message

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
           "default": "off",
           "enum": [
             "off",
-            "messages",
+            "message",
             "verbose"
           ],
           "description": "Trace level of log"

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -2,7 +2,7 @@ import { OutputChannel, workspace, Uri } from 'coc.nvim';
 import { devLogName } from './constant';
 import { Dispose } from './dispose';
 
-export type logLevel = 'off' | 'messages' | 'verbose';
+export type logLevel = 'off' | 'message' | 'verbose';
 
 class Logger extends Dispose {
   private _outchannel: OutputChannel | undefined;


### PR DESCRIPTION
The `messages` log level is not correct on beta, not sure what happens on stable tbh, on the newer versions it should be `message`