### PR TITLE
SDK switching support

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,17 @@
           "default": true,
           "description": "Enable checking of fvm directories to find flutter install"
         },
+        "flutter.sdk.path": {
+          "type": "string",
+          "default": [],
+          "description": "The path of the flutter sdk to use. (When using the `FlutterSDKs` list to change sdk this value will be updated)"
+        },
+        "flutter.sdk.searchPaths": {
+          "type": "array",
+          "default": [],
+          "item": "string",
+          "description": "The paths to search for flutter sdks, either directories where flutter is installed or directories which contain directories where flutter versions have been installed\neg. /path/to/flutter (command at /path/to/flutter/bin/flutter) \n~/flutter_versions (command at ~/flutter_versions/version/bin/flutter)."
+        },
         "flutter.lsp.debug": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,11 @@
           "default": true,
           "description": "Enable coc-flutter extension"
         },
+        "flutter.fvm.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable checking of fvm directories to find flutter install"
+        },
         "flutter.lsp.debug": {
           "type": "boolean",
           "default": false,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,10 +3,11 @@ import { Dev } from './dev';
 import { Global } from './global';
 import { LspServer } from '../server/lsp';
 import { SuperCommand } from './super';
+import { LspCommands } from './lsp';
 
 export class Commands extends Dispose {
   constructor(lsp: LspServer) {
     super();
-    this.push(new Dev(), new Global(), new SuperCommand(lsp));
+    this.push(new Dev(), new Global(), new LspCommands(lsp), new SuperCommand(lsp));
   }
 }

--- a/src/commands/lsp.ts
+++ b/src/commands/lsp.ts
@@ -1,0 +1,27 @@
+import { Dispose } from '../util/dispose';
+import { LspServer } from '../server/lsp';
+import { commands } from 'coc.nvim';
+import { cmdPrefix } from '../util/constant';
+import { notification } from '../lib/notification';
+
+export class LspCommands extends Dispose {
+  private restartCmdId = `${cmdPrefix}.lsp.restart`;
+
+  constructor(lsp: LspServer) {
+    super();
+    this.push(
+      commands.registerCommand(this.restartCmdId, async () => {
+        if (!lsp.client) {
+          return notification.show('analyzer LSP server is not running');
+        }
+        await lsp.restart();
+      }),
+    );
+    commands.titles.set(this.restartCmdId, 'restart the lsp server');
+  }
+
+  dispose(): void {
+    super.dispose();
+    commands.titles.delete(this.restartCmdId);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,5 +30,5 @@ export async function activate(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(new Providers());
 
   // register sources
-  context.subscriptions.push(new SourceList());
+  context.subscriptions.push(new SourceList(lsp));
 }

--- a/src/lib/sdk.ts
+++ b/src/lib/sdk.ts
@@ -1,6 +1,6 @@
 import os, { homedir } from 'os';
 import { join, dirname } from 'path';
-import { workspace, WorkspaceConfiguration } from 'coc.nvim';
+import { Uri, workspace, WorkspaceConfiguration } from 'coc.nvim';
 import which from 'which';
 import { logger } from '../util/logger';
 import { exists, getRealPath, execCommand, readDir } from '../util/fs';
@@ -149,7 +149,7 @@ class FlutterSDK {
 
   private async initDartSdkHomeFromLocalFvm() {
     try {
-      const fvmLocation = join(workspace.workspaceFolder.uri.replace(/^file:/, ''), '.fvm/flutter_sdk');
+      const fvmLocation = join(Uri.parse(workspace.workspaceFolder.uri).fsPath, '.fvm','flutter_sdk');
       if (await exists(fvmLocation)) {
         log('Found local fvm sdk');
         this._sdkHome = fvmLocation;

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -11,7 +11,7 @@ class StatusBar extends Dispose {
 
   ready() {
     this.isLSPReady = true;
-    this.show('flutter');
+    this.show('flutter', false);
   }
 
   init() {
@@ -34,6 +34,11 @@ class StatusBar extends Dispose {
         },
       }),
     );
+  }
+
+  restartingLsp() {
+    this.isLSPReady = false;
+    this.show('restartingLsp', true);
   }
 
   show(message: string, isProgress?: boolean) {

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -5,6 +5,10 @@ class StatusBar extends Dispose {
   private isLSPReady = false;
   private statusBar: StatusBarItem | undefined = undefined;
 
+  get isInitialized(): boolean {
+    return this.statusBar != undefined;
+  }
+
   ready() {
     this.isLSPReady = true;
     this.show('flutter');

--- a/src/server/lsp/index.ts
+++ b/src/server/lsp/index.ts
@@ -33,12 +33,14 @@ export class LspServer extends Dispose {
     return this._client;
   }
 
-  async init() {
+  async init(): Promise<void> {
     const config = workspace.getConfiguration('flutter');
     // is force lsp debug
     const isLspDebug = config.get<boolean>('lsp.debug');
     // dart sdk analysis snapshot path
-    await flutterSDK.init(config);
+    if (!flutterSDK.state) {
+      await flutterSDK.init(config);
+    }
 
     if (!flutterSDK.state) {
       log('flutter SDK not found!');
@@ -144,5 +146,13 @@ export class LspServer extends Dispose {
     // Push the disposable to the context's subscriptions so that the
     // client can be deactivated on extension deactivation
     this.push(services.registLanguageClient(client));
+  }
+
+  async restart(): Promise<void> {
+    // await services.stop(this._client!.id);
+    // await this._client?.stop();
+
+    // await this.init();
+    // this._client?.
   }
 }

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -1,12 +1,18 @@
 import { listManager } from 'coc.nvim';
+import { LspServer } from '../server/lsp';
 
 import { Dispose } from '../util/dispose';
 import DevicesList from './devices';
 import EmulatorsList from './emulators';
+import SdksList from './sdks';
 
 export class SourceList extends Dispose {
-  constructor() {
+  constructor(lsp: LspServer) {
     super();
-    this.push(listManager.registerList(new DevicesList()), listManager.registerList(new EmulatorsList()));
+    this.push(
+      listManager.registerList(new DevicesList()),
+      listManager.registerList(new EmulatorsList()),
+      listManager.registerList(new SdksList(lsp)),
+    );
   }
 }

--- a/src/sources/sdks.ts
+++ b/src/sources/sdks.ts
@@ -1,21 +1,10 @@
 import { commands, IList, ListAction, ListItem, workspace } from 'coc.nvim';
 import colors from 'colors/safe';
 
-import { flutterSDK } from '../lib/sdk';
+import { flutterSDK, FlutterSdk } from '../lib/sdk';
 import { execCommand, exists, getRealPath, readDir } from '../util/fs';
-import { join } from 'path';
-import { readFile } from 'fs/promises';
 import { logger } from '../util/logger';
-import { homedir } from 'os';
 import { LspServer } from '../server/lsp';
-
-interface Sdk {
-  location: string;
-  version: string;
-  fvmVersion?: string;
-  isFvm: boolean;
-  isCurrent: boolean;
-}
 
 const log = logger.getlog('SdksList')
 
@@ -27,13 +16,13 @@ export default class SdksList implements IList {
 
   constructor(lsp: LspServer) {
     this.actions.push({
-      name: 'switch',
+      name: 'project only switch',
       multiple: false,
       execute: async (item) => {
         if (Array.isArray(item)) {
           return;
         }
-        let sdk: Sdk = item.data;
+        let sdk: FlutterSdk = item.data;
         if (sdk.isCurrent) return;
         const config = workspace.getConfiguration('flutter');
         if (sdk.isFvm) {
@@ -45,87 +34,29 @@ export default class SdksList implements IList {
         }
         await flutterSDK.reloadWithSdk(sdk.location);
         await lsp.restart();
-       commands.executeCommand('flutter.pub.get');
+        commands.executeCommand('flutter.pub.get');
+      },
+    });
+    this.actions.push({
+      name: 'switch',
+      multiple: false,
+      execute: async (item) => {
+        if (Array.isArray(item)) {
+          return;
+        }
+        let sdk: FlutterSdk = item.data;
+        if (sdk.isCurrent) return;
+        const config = workspace.getConfiguration('flutter');
+        config.update('sdk.path', sdk.location, true);
+        await flutterSDK.reloadWithSdk(sdk.location);
+        await lsp.restart();
+        commands.executeCommand('flutter.pub.get');
       },
     });
   }
 
   public async loadItems(): Promise<ListItem[]> {
-    let sdks: Sdk[] = [];
-
-    let currentSdk = await getRealPath(flutterSDK.sdkHome);
-
-    const config = workspace.getConfiguration('flutter');
-    const fvmEnabled = config.get<boolean>('fvm.enabled', true);
-    let home = homedir();
-
-    if (fvmEnabled) {
-      let fvmCachePath = join(home, 'fvm', 'versions');
-      const settingsPath = join(home, 'fvm', '.settings');
-      try {
-        const fvmSettingsFileExists = exists(settingsPath);
-        if (fvmSettingsFileExists) {
-          const settingsRaw = await readFile(settingsPath);
-          const settings = JSON.parse(settingsRaw.toString());
-          if (typeof(settings.cachePath) == 'string' && settings.cachePath.trim() != '') {
-            fvmCachePath = settings.cachePath;
-          }
-        }
-      } catch(error) {
-        log(`Failed to load fvm settings: ${error.message}`);
-      }
-
-      const fvmVersions = await readDir(fvmCachePath);
-      for (const version of fvmVersions) {
-        let location = join(fvmCachePath, version);
-        const isFlutterDir = await exists(join(location, 'bin', 'flutter'));
-        if (!isFlutterDir) continue;
-        const flutterVersion = await execCommand(`cat ${join(location, 'version')}`);
-        sdks.push({
-          location: location,
-          fvmVersion: version,
-          isFvm: true,
-          version: flutterVersion.err ? version: `${version} (${flutterVersion.stdout})`,
-          isCurrent: location == currentSdk,
-        });
-      }
-    }
-
-
-
-    const paths = config.get<string[]>('sdk.searchPaths', []);
-
-    for (let path of paths) {
-      path = path.replace('~', home);
-      const isFlutterDir = await exists(join(path, 'bin', 'flutter'));
-      if (isFlutterDir) {
-        const version = await execCommand(`cat ${join(path, 'version')}`);
-        if (!version.err) {
-          sdks.push({
-            location: path,
-            isFvm: false,
-            version: version.stdout,
-            isCurrent: path == currentSdk,
-          });
-          continue;
-        }
-      }
-
-      const files = await readDir(path);
-      for (const file of files) {
-        let location = join(path, file);
-        const isFlutterDir = await exists(join(location, 'bin', 'flutter'));
-        if (!isFlutterDir) continue;
-        const version = await execCommand(`cat ${join(location, 'version')}`);
-        sdks.push({
-          location: location,
-          isFvm: false,
-          version: version.err ? 'unknown' : version.stdout,
-          isCurrent: location == currentSdk,
-        });
-      }
-    }
-
+    const sdks = await flutterSDK.findSdks();
     return sdks.map(sdk => {
       return {
         label: `${sdk.isCurrent ? colors.yellow(sdk.version) + colors.bold(' (current)') : colors.yellow(sdk.version)} • ${colors.gray(

--- a/src/sources/sdks.ts
+++ b/src/sources/sdks.ts
@@ -32,9 +32,9 @@ export default class SdksList implements IList {
         } else {
           config.update('sdk.path', sdk.location);
         }
-        await flutterSDK.reloadWithSdk(sdk.location);
+        await lsp.reloadSdk();
+        await commands.executeCommand('flutter.pub.get');
         await lsp.restart();
-        commands.executeCommand('flutter.pub.get');
       },
     });
     this.actions.push({
@@ -48,7 +48,6 @@ export default class SdksList implements IList {
         if (sdk.isCurrent) return;
         const config = workspace.getConfiguration('flutter');
         config.update('sdk.path', sdk.location, true);
-        await flutterSDK.reloadWithSdk(sdk.location);
         await lsp.restart();
         commands.executeCommand('flutter.pub.get');
       },

--- a/src/sources/sdks.ts
+++ b/src/sources/sdks.ts
@@ -1,0 +1,139 @@
+import { commands, IList, ListAction, ListItem, workspace } from 'coc.nvim';
+import colors from 'colors/safe';
+
+import { flutterSDK } from '../lib/sdk';
+import { execCommand, exists, getRealPath, readDir } from '../util/fs';
+import { join } from 'path';
+import { readFile } from 'fs/promises';
+import { logger } from '../util/logger';
+import { homedir } from 'os';
+import { LspServer } from '../server/lsp';
+
+interface Sdk {
+  location: string;
+  version: string;
+  fvmVersion?: string;
+  isFvm: boolean;
+  isCurrent: boolean;
+}
+
+const log = logger.getlog('SdksList')
+
+export default class SdksList implements IList {
+  public readonly name = 'FlutterSDKs';
+  public readonly description = 'list of local flutter sdks';
+  public readonly defaultAction = 'switch';
+  public actions: ListAction[] = [];
+
+  constructor(lsp: LspServer) {
+    this.actions.push({
+      name: 'switch',
+      multiple: false,
+      execute: async (item) => {
+        if (Array.isArray(item)) {
+          return;
+        }
+        let sdk: Sdk = item.data;
+        if (sdk.isCurrent) return;
+        const config = workspace.getConfiguration('flutter');
+        if (sdk.isFvm) {
+          await execCommand(`fvm use ${sdk.fvmVersion!}`);
+          config.update('sdk.path', '.fvm/flutter_sdk');
+          log(`swithed to ${sdk.version} using fvm`);
+        } else {
+          config.update('sdk.path', sdk.location);
+        }
+        await flutterSDK.reloadWithSdk(sdk.location);
+        await lsp.restart();
+       commands.executeCommand('flutter.pub.get');
+      },
+    });
+  }
+
+  public async loadItems(): Promise<ListItem[]> {
+    let sdks: Sdk[] = [];
+
+    let currentSdk = await getRealPath(flutterSDK.sdkHome);
+
+    const config = workspace.getConfiguration('flutter');
+    const fvmEnabled = config.get<boolean>('fvm.enabled', true);
+    let home = homedir();
+
+    if (fvmEnabled) {
+      let fvmCachePath = join(home, 'fvm', 'versions');
+      const settingsPath = join(home, 'fvm', '.settings');
+      try {
+        const fvmSettingsFileExists = exists(settingsPath);
+        if (fvmSettingsFileExists) {
+          const settingsRaw = await readFile(settingsPath);
+          const settings = JSON.parse(settingsRaw.toString());
+          if (typeof(settings.cachePath) == 'string' && settings.cachePath.trim() != '') {
+            fvmCachePath = settings.cachePath;
+          }
+        }
+      } catch(error) {
+        log(`Failed to load fvm settings: ${error.message}`);
+      }
+
+      const fvmVersions = await readDir(fvmCachePath);
+      for (const version of fvmVersions) {
+        let location = join(fvmCachePath, version);
+        const isFlutterDir = await exists(join(location, 'bin', 'flutter'));
+        if (!isFlutterDir) continue;
+        const flutterVersion = await execCommand(`cat ${join(location, 'version')}`);
+        sdks.push({
+          location: location,
+          fvmVersion: version,
+          isFvm: true,
+          version: flutterVersion.err ? version: `${version} (${flutterVersion.stdout})`,
+          isCurrent: location == currentSdk,
+        });
+      }
+    }
+
+
+
+    const paths = config.get<string[]>('sdk.searchPaths', []);
+
+    for (let path of paths) {
+      path = path.replace('~', home);
+      const isFlutterDir = await exists(join(path, 'bin', 'flutter'));
+      if (isFlutterDir) {
+        const version = await execCommand(`cat ${join(path, 'version')}`);
+        if (!version.err) {
+          sdks.push({
+            location: path,
+            isFvm: false,
+            version: version.stdout,
+            isCurrent: path == currentSdk,
+          });
+          continue;
+        }
+      }
+
+      const files = await readDir(path);
+      for (const file of files) {
+        let location = join(path, file);
+        const isFlutterDir = await exists(join(location, 'bin', 'flutter'));
+        if (!isFlutterDir) continue;
+        const version = await execCommand(`cat ${join(location, 'version')}`);
+        sdks.push({
+          location: location,
+          isFvm: false,
+          version: version.err ? 'unknown' : version.stdout,
+          isCurrent: location == currentSdk,
+        });
+      }
+    }
+
+    return sdks.map(sdk => {
+      return {
+        label: `${sdk.isCurrent ? colors.yellow(sdk.version) + colors.bold(' (current)') : colors.yellow(sdk.version)} • ${colors.gray(
+          `${sdk.location}`,
+        )}`,
+        filterText: sdk.location,
+        data: sdk,
+      };
+    });
+  }
+}

--- a/src/sources/sdks.ts
+++ b/src/sources/sdks.ts
@@ -16,7 +16,7 @@ export default class SdksList implements IList {
 
   constructor(lsp: LspServer) {
     this.actions.push({
-      name: 'project only switch',
+      name: 'switch',
       multiple: false,
       execute: async (item) => {
         if (Array.isArray(item)) {
@@ -38,7 +38,7 @@ export default class SdksList implements IList {
       },
     });
     this.actions.push({
-      name: 'switch',
+      name: 'global switch',
       multiple: false,
       execute: async (item) => {
         if (Array.isArray(item)) {

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -98,3 +98,15 @@ export const getRealPath = async (path: string): Promise<string> => {
   }
   return path;
 };
+
+export const readDir = async(path: string, options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | undefined | null): Promise<string[]> => {
+  return new Promise(resolve => {
+    fs.readdir(path, options, (err, files) => {
+      if (err) {
+        return resolve([]);
+      } else {
+        return resolve(files);
+      }
+    })
+  });
+}


### PR DESCRIPTION
I added fvm support and an sdk selector list
When you select an sdk using the list it sets the `flutter.sdk.path` config option in the local config which is also used on startup. If that's not found it will try to use fvm if enabled(which is the default) and otherwise fallback on the old way.
So perhaps we should deprecate the `flutter-lookup` config option?

Restarting of the lsp server gave me some issues though (so it does not do that yet)
@iamcco It does not seem needed to restart the server in my testing since with doing the pub get the server will simply switch to the new flutter location so only any updates to the analysis snapshot itself will be missing, but do you perhaps know how to get the restart working?

Fixes #90
Fixes #87
Fixes #96