### PR TITLE
fix(output): let coc handle disposing of the output channels

### DIFF
--- a/src/server/lsp/index.ts
+++ b/src/server/lsp/index.ts
@@ -53,7 +53,7 @@ export class LspServer extends Dispose {
 
   async init(): Promise<void> {
     this.outchannel = window.createOutputChannel('flutter-lsp');
-    this.push(this.outchannel);
+    this.outchannel.clear();
     const config = workspace.getConfiguration('flutter');
     // is force lsp debug
     const isLspDebug = config.get<boolean>('lsp.debug');

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -13,12 +13,8 @@ class Logger extends Dispose {
     this._traceServer = level;
     if (this._traceServer !== 'off') {
       this._outchannel = window.createOutputChannel('flutter');
-      this.push(this._outchannel);
+      this._outchannel?.clear();
     }
-  }
-
-  set outchannel(channel: OutputChannel | undefined) {
-    this._outchannel = channel;
   }
 
   get outchannel(): OutputChannel | undefined {
@@ -28,7 +24,7 @@ class Logger extends Dispose {
   get devOutchannel(): OutputChannel {
     if (!this._devOutchannel) {
       this._devOutchannel = window.createOutputChannel(devLogName);
-      this.push(this._devOutchannel);
+      this._devOutchannel?.clear();
     }
     return this._devOutchannel;
   }


### PR DESCRIPTION
This fixes the outputs not getting filled again when the extension is reloaded.
I also made a pr to coc to fix the recreating but in general I think this approach is better