### PR TITLE
Improved handling for already opened DevLog window

### DIFF
--- a/src/server/dev/index.ts
+++ b/src/server/dev/index.ts
@@ -164,7 +164,7 @@ class DevServer extends Dispose {
     const cmd = config.get<string>('openDevLogSplitCommand', '');
 
     if (this.outputChannel) {
-      const winId = await workspace.nvim.call('bufwinid', "output:///" + devLogName);
+      const winId = await workspace.nvim.call('bufwinid', 'output:///' + devLogName);
       if (winId >= 0) {
         workspace.nvim.call('win_gotoid', [winId]);
       } else {

--- a/src/server/dev/index.ts
+++ b/src/server/dev/index.ts
@@ -162,17 +162,24 @@ class DevServer extends Dispose {
   async openDevLog(preserveFocus?: boolean) {
     const config = workspace.getConfiguration('flutter');
     const cmd = config.get<string>('openDevLogSplitCommand', '');
+
     if (this.outputChannel) {
-      if (!cmd) {
-        this.outputChannel.show(preserveFocus);
+      const winId = await workspace.nvim.call('bufwinid', "output:///" + devLogName);
+      if (winId >= 0) {
+        workspace.nvim.call('win_gotoid', [winId]);
       } else {
-        const win = await workspace.nvim.window;
-        await workspace.nvim.command(`${cmd} output:///${devLogName}`);
-        if (!preserveFocus) {
-          workspace.nvim.call('win_gotoid', [win.id]);
+        if (!cmd) {
+          this.outputChannel.show(preserveFocus);
+        } else {
+          const win = await workspace.nvim.window;
+          await workspace.nvim.command(`${cmd} output:///${devLogName}`);
+          if (!preserveFocus) {
+            workspace.nvim.call('win_gotoid', [win.id]);
+          }
         }
       }
     }
+
     setTimeout(() => {
       this.autoScrollLogWin();
     }, 1000);


### PR DESCRIPTION
This pull request addresses an issue experienced when the 'openDevLogSplitCommand' configuration is set to options like 'split'.

When this configuration is used, a new DevLog window is opened every time, even if there is an existing one already opened, which leads to multiple DevLog windows being open at the same time.
